### PR TITLE
Add meeting checklist for 2022 Sprint week

### DIFF
--- a/index-aug-2022-chicago.html
+++ b/index-aug-2022-chicago.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-     <title>Checklist for the October 2022 LSST DESC Sprint Week</title>
+     <title>Checklist for the August 2022 LSST DESC Collaboration Meeting</title>
      <meta http-equiv="content-type" content="text/html; charset=utf-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" rel="stylesheet">
@@ -86,9 +86,9 @@
 
 <body>
      <div id="page">
-          <h1>Checklist for the October 2022 LSST DESC Sprint Week</h1>
+          <h1>Checklist for the August 2022 LSST DESC Collaboration Meeting</h1>
           <h3>Here are a few useful things you can do to prepare yourself for
-               the Sprint Week!</h3>
+               our first hybrid Collaboration Meeting in over two years!</h3>
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <div class="progress-container">
           <div id="progress"><div id="progress-text"></div></div>
@@ -106,8 +106,8 @@
           </div>
           <div class="text">
                Check out and bookmark the
-               <a href="https://confluence.slac.stanford.edu/x/LCRaFQ"
-               title="link to Confluence">Sprint Week confluence page</a>
+               <a href="https://confluence.slac.stanford.edu/x/CZh8F"
+               title="link to Confluence">Collaboration Meeting confluence page</a>
                 (on all the devices that you plan to use). Make sure you remember your Confluence password.
           </div>
      </div>
@@ -119,9 +119,9 @@
           </div>
           <div class="text">
                Check out the
-               <a href="https://confluence.slac.stanford.edu/x/RiRaFQ"
-               title="link to the calendar">schedule</a>.
-               You can subscribe to the calendar linked there to keep up to date on all the events for the week.
+               <a href="https://teamup.com/ks2nhg3xz1r89ocgio"
+               title="link to the TeamUp Calendar">Meeting Agenda</a> page.
+               You can subscribe to the calendar to keep up to date on all the events for the week.
           </div>
      </div>
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -132,11 +132,25 @@
           </div>
           <div class="text">
                Check out the
-               <a href="https://confluence.slac.stanford.edu/x/QSRaFQ"
-               title="link to Confluence">logistics page</a>
-               for details on e.g., participation modes, remote and in-person logistics as well as computing resources, Slack channels, and Zoom access.
+               <a href="https://confluence.slac.stanford.edu/x/NtR8F"
+               title="link to Confluence">logistics and guidelines page</a>
+               for details on e.g., participation guidelines, Slack channels and Zoom.
           </div>
      </div>
+     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+     <!-- COVID -->
+          <div class="item">
+          <div class="box">
+               <input type="checkbox">
+          </div>
+          <div class="text">Remind yourself of our COVID guidelines which apply
+	        to all participants by visiting the 
+               <a href="https://confluence.slac.stanford.edu/x/CZh8F"
+               title="link to meeting main page">main meeting page</a>
+               and scrolling down a bit.
+          </div>
+     </div>
+
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- CoC -->
      <div class="item">
@@ -161,9 +175,12 @@
                <input type="checkbox">
           </div>
           <div class="text">
-               Ensure that your Zoom and Slack apps are up-to-date.
+               Ensure that your Zoom and Slack apps are up-to-date. (Note that Zoom has released >69 updates since the July 2021 meeting!)
           </div>
      </div>
+     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+     <!-- Wonder setup.  Leave this out for Aug 2022 -->
+
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- pronouns -->
      <div class="item">
@@ -185,10 +202,9 @@
 		       <a href="https://support.zoom.us/hc/en-us/articles/4402698027533-Adding-and-sharing-your-pronouns">personal pronoun feature</a>.
                (Note: this option may not be available on some of the institutional accounts.)
                </li>
-               <br>
                <!-- slack -->
                <li>
-                  In LSSTC Slack workspace, you can add your pronouns to your profile by 1)
+                  In the LSSTC Slack workspace, you can add your pronouns to your profile by 1)
                   clicking on your name, 2) clicking the "Edit Profile" button,
                   and 3) filling out/updating the "Pronouns" entry.
                </li>
@@ -202,7 +218,7 @@
                <input type="checkbox">
           </div>
           <div class="text">
-               Consider setting your Slack status icon to <i>:hacking:</i> to advertise your availability for Sprint activities.
+               Consider setting your Slack status as active if you are available for synchronous activities.
           </div>
      </div>
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -217,13 +233,13 @@
                <!-- collab-mtg channel -->
                <li>
                    <a href="https://lsstc.slack.com/archives/C90AMAG80"
-                   title="link to LSSTC Slack">#desc-hack-sprint</a>
+                   title="link to LSSTC Slack">#desc-collab-meeting</a>
                     to hear announcements and daily briefings.
                </li>
                <!-- tech hotline -->
                <li>
                   <a href="https://lsstc.slack.com/archives/C0176US657B"
-                  title="link to LSSTC Slack">#desc-sprint-hotline</a>
+                  title="link to LSSTC Slack">#desc-collab-meeting-hotline</a>
                     to report any technical problems that may arise during the meeting.
                </li>
                </ul>
@@ -233,23 +249,9 @@
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- Computing etc. -->
-     <h2>Computing resources, datasets etc.</h2>
-     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-     <!-- IN2P3 -->
-     <h3>IN2P3</h3>
-     <div class="item">
-        <div class="box">
-             <input type="checkbox">
-        </div>
-        <div class="text">
-            As an LSST DESC member, you can request the setup of an IN2P3 account, you will find all the necessary information <a href="https://doc.cc.in2p3.fr/en/Getting-started/start.html#computing-account">here</a>.
-            Pay attention to requesting your account before the beginning of the week, as it’s quick but might still need 24 to 48h to be up and running.
-        </div>
-     </div>
-
+     <h2>Computing resources etc.</h2>
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- NERSC -->
-     <h3>NERSC</h3>
      <div class="item">
           <div class="box">
                <input type="checkbox">
@@ -274,7 +276,7 @@
                Also, make sure you are in the NERSC "lsst" group.
 	       (Once logged into NERSC, run the "groups" command in a shell window.)
 	       If not, request help from either the #desc-help
-	       or #desc-nersc Slack channel.  Or you may send an email to
+	       or #desc-nersc Slack channel.  Or you may send email to
 	       lsst-desc-help@slac.stanford.edu.  Or you may contact
                Heather Kelly, Seth Digel, or Debbie Bard via Slack.
           </div>
@@ -293,21 +295,7 @@
           </div>
      </div>
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-     <!-- Rubin Science Platform -->
-     <h3>Rubin Science Platform</h3>
-     <div class="item">
-        <div class="box">
-             <input type="checkbox">
-        </div>
-        <div class="text">
-            If you are a DP0 delegate and plan on using the Rubin Science Platform (RSP), please ensure that you are able to login.
-            Check out <a href="https://community.lsst.org/t/faq-technical-aspects-of-rubin-science-platform-accounts-for-dp0/4791">
-                this post on Community</a> for the technical aspects of RSP.
-        </div>
-     </div>
-     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- DC2 -->
-     <h3>DC2</h3>
      <div class="item">
           <div class="box">
                <input type="checkbox">
@@ -327,28 +315,6 @@
                channel.
           </div>
      </div>
-     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-     <!-- In-person component -->
-     <h2>Attending in-person</h2>
-     <div class="item">
-        <div class="box">
-             <input type="checkbox">
-        </div>
-        <div class="text">
-            Please review the COVID policy posted on the <a href="https://confluence.slac.stanford.edu/x/LCRaFQ">Meeting page</a>.
-        </div>
-   </div>
-     <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-     <!-- Hub-specific channel -->
-     <div class="item">
-        <div class="box">
-             <input type="checkbox">
-        </div>
-        <div class="text">
-                Please join the following Slack channel for local announcements: <a href="https://lsstc.slack.com/archives/C045ZU9PME0">#desc-sprint2022-umich</a>.
-        </div>
-   </div>
 
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
      <!-- +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
@@ -377,7 +343,7 @@
      <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
      <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
      <script>
-     const cookie_key = "lsst_desc_pre_meeting_checklist_Oct2021";
+     const cookie_key = "lsst_desc_pre_meeting_checklist_Feb2022";
      const get_progress = function () {
           return (0.5 + 99.5 / $("input").length * $("input:checked").length);
      }

--- a/index.html
+++ b/index.html
@@ -377,7 +377,7 @@
      <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
      <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
      <script>
-     const cookie_key = "lsst_desc_pre_meeting_checklist_Oct2021";
+     const cookie_key = "lsst_desc_pre_meeting_checklist_Oct2022";
      const get_progress = function () {
           return (0.5 + 99.5 / $("input").length * $("input:checked").length);
      }

--- a/index.html
+++ b/index.html
@@ -216,13 +216,13 @@
                <ul>
                <!-- collab-mtg channel -->
                <li>
-                   <a href="https://lsstc.slack.com/archives/C90AMAG80"
+                   <a href="https://lsstc.slack.com/archives/C2M8FG5A6"
                    title="link to LSSTC Slack">#desc-hack-sprint</a>
                     to hear announcements and daily briefings.
                </li>
                <!-- tech hotline -->
                <li>
-                  <a href="https://lsstc.slack.com/archives/C0176US657B"
+                  <a href="https://lsstc.slack.com/archives/C01EY4AK7UJ"
                   title="link to LSSTC Slack">#desc-sprint-hotline</a>
                     to report any technical problems that may arise during the meeting.
                </li>
@@ -242,7 +242,7 @@
              <input type="checkbox">
         </div>
         <div class="text">
-            As an LSST DESC member, you can request the setup of an IN2P3 account, you will find all the necessary information <a href="https://doc.cc.in2p3.fr/en/Getting-started/start.html#computing-account">here</a>.
+            As an LSST DESC member, you can request the setup of an IN2P3 account, you will find all the necessary information <a href="https://doc.cc.in2p3.fr/en/Getting-started/access.html">here</a>.
             Pay attention to requesting your account before the beginning of the week, as it’s quick but might still need 24 to 48h to be up and running.
         </div>
      </div>


### PR DESCRIPTION
This PR updates the meeting checklist to correspond to the 2022 sprint week.

It broadly just inherits from the Oct. 2021 checklists, with minor adaptations to this years format.